### PR TITLE
Make compression level a configurable option

### DIFF
--- a/CyLR/src/Arguments.cs
+++ b/CyLR/src/Arguments.cs
@@ -47,6 +47,10 @@ namespace CyLR
                 "Uses a password to encrypt the archive file"
             },
             {
+                "-zl",
+                "Uses a number between 1-9 to change the compression level of the archive file"
+            },
+            {
                 "--no-usnjrnl",
                 "Skips collecting $UsnJrnl"
             }
@@ -67,12 +71,12 @@ namespace CyLR
         public readonly bool DryRun;
         public readonly bool ForceNative;
         public readonly string ZipPassword;
+        public readonly string ZipLevel;
         public readonly bool Usnjrnl = true;
 
         public Arguments(IEnumerable<string> args)
         {
             ForceNative = !Platform.SupportsRawAccess(); //default this to whether or not the platform supports raw access
-
             var argEnum = args.GetEnumerator();
             while (!HelpRequested && argEnum.MoveNext())
             {
@@ -109,6 +113,10 @@ namespace CyLR
                     case "-zp":
                         ZipPassword = argEnum.GetArgumentParameter();
                         break;
+
+                    case "-zl":
+                        ZipLevel = argEnum.GetArgumentParameter();
+                        break; 
 
                     case "--no-usnjrnl":
                         Usnjrnl = false;

--- a/CyLR/src/Program.cs
+++ b/CyLR/src/Program.cs
@@ -107,8 +107,13 @@ namespace CyLR
         private static void CreateArchive(Arguments arguments, Stream archiveStream, IEnumerable<string> paths)
         {
             try
-            {
-                using (var archive = new SharpZipArchive(archiveStream, arguments.ZipPassword))
+            {   
+                string ZipLevel = "3";
+                if (!String.IsNullOrEmpty(arguments.ZipLevel))
+                {
+                   ZipLevel = arguments.ZipLevel;
+                }
+                using (var archive = new SharpZipArchive(archiveStream, arguments.ZipPassword, ZipLevel ))
                 {
                     var system = arguments.ForceNative ? (IFileSystem)new NativeFileSystem() : new RawFileSystem();
 

--- a/CyLR/src/archive/SharpZipArchive.cs
+++ b/CyLR/src/archive/SharpZipArchive.cs
@@ -8,7 +8,7 @@ namespace CyLR.archive
     {
         private readonly ZipOutputStream archive;
 
-        public SharpZipArchive(Stream destination, String password)
+        public SharpZipArchive(Stream destination, String password, String level)
             : base(destination)
         {
             archive = new ZipOutputStream(destination);
@@ -17,7 +17,11 @@ namespace CyLR.archive
             {
                 archive.Password = password;
             }
-            
+            if(Convert.ToInt32(level) >=1 || Convert.ToInt32(level) <= 9)
+            {
+                archive.SetLevel(Convert.ToInt32(level));
+            }
+                
         }
 
         protected override void WriteStreamToArchive(string entryName, Stream stream, DateTimeOffset timestamp)
@@ -27,8 +31,6 @@ namespace CyLR.archive
                 DateTime = timestamp.DateTime
             };
             archive.PutNextEntry(entry);
-            archive.SetLevel(3);
-
             stream.CopyTo(archive);
             archive.CloseEntry();
         }

--- a/CyLRTests/archive/SharpZipArchiveTests.cs
+++ b/CyLRTests/archive/SharpZipArchiveTests.cs
@@ -20,7 +20,7 @@ namespace CyLRTests.archive
             var testData = Encoding.Unicode.GetBytes(entryData);
             var testFileData = new MemoryStream(testData);
             CyLR.archive.File file = new CyLR.archive.File(entryName, testFileData, new DateTime());
-            var zipFile = CreateZipArchive(new[] { file }, "");
+            var zipFile = CreateZipArchive(new[] { file }, "","3");
 
             //Unzip that data
             var unzippedData = new MemoryStream();
@@ -40,11 +40,12 @@ namespace CyLRTests.archive
             string entryName = "TestFile";
             string entryData = "TestData";
             string archivePassword = "TestPassword";
+            string archiveCompressionLevel = "3";
             //Zip up some data
             var testData = Encoding.Unicode.GetBytes(entryData);
             var testFileData = new MemoryStream(testData);
             CyLR.archive.File file = new CyLR.archive.File(entryName, testFileData, new DateTime());
-            var zipFile = CreateZipArchive(new[] { file }, archivePassword);
+            var zipFile = CreateZipArchive(new[] { file }, archivePassword, archiveCompressionLevel);
 
             //Unzip that data
             var unzippedData = new MemoryStream();
@@ -65,10 +66,10 @@ namespace CyLRTests.archive
             Assert.Equal(testData, unzippedData.ToArray());
         }
 
-        private static MemoryStream CreateZipArchive(IEnumerable<CyLR.archive.File> testData, string password)
+        private static MemoryStream CreateZipArchive(IEnumerable<CyLR.archive.File> testData, string password, string level)
         {
             var zipFile = new MemoryStream();
-            var archive = new SharpZipArchive(zipFile, password);
+            var archive = new SharpZipArchive(zipFile, password, level);
             using (archive)
             {
                 archive.CollectFilesToArchive(testData);

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ CyLR uses .NET Core and runs natively on Windows, Linux, and MacOS. Self contain
 ## SYNOPSIS
 
 ```
-CyLR.exe [--help] [-od] [-of] [-u] [-p] [-s] [-c] [-zp]
+CyLR.exe [--help] [-od] [-of] [-u] [-p] [-s] [-c] [-zp] [-zl]
 ```
 
 ## DESCRIPTION
@@ -108,6 +108,7 @@ Mac and Linux Default
 * '-od' — Defines the directory that the zip archive will be created in. Defaults to current working directory. (applies to SFTP and local storage options)
 * '-of' — Defines the name of the zip archive will be created. Defaults to host machine's name.
 * '-zp' — If specified, the resulting zip file will be password protected with this password.
+* '-zl [1-9]' - If specified with an integer it will change the compression level. If the flag is not passed it defaults to 3.  
 * SFTP Options
     * '-u' — SFTP username
     * '-p' — SFTP password


### PR DESCRIPTION
I added the option to set the compression level and got the following results.

.\CyLR.exe -zl 1 493 MB (517,574,509 bytes)
.\CyLR.exe -zl 9 435 MB (457,043,472 bytes)
.\CyLR.exe (implicit 3) 471 MB (494,489,472 bytes)

I do a lot of python programming and this was my first attempt at c# so please forgive some of my shortcomings. Let me know what you all think and please provide feedback on how to do some of these things in a better way. 