### PR TITLE
Draft: Address timestamps in unit tests

### DIFF
--- a/CyLRTests/TestCollectionPaths.cs
+++ b/CyLRTests/TestCollectionPaths.cs
@@ -19,6 +19,7 @@ namespace CyLRTests
             var userProfile = Environment.ExpandEnvironmentVariables("%HOME%");
             var logger = new CyLR.Logger();
             logger.LoggingOptions["output_file_path"] = "1.log";
+            logger.LoggingOptions["output_console_min_level"] = "error";
             logger.Setup();
 
             // Set platform specific variables.
@@ -69,6 +70,7 @@ namespace CyLRTests
             var userProfile = Environment.ExpandEnvironmentVariables("%HOME%");
             var logger = new CyLR.Logger();
             logger.LoggingOptions["output_file_path"] = "2.log";
+            logger.LoggingOptions["output_console_min_level"] = "error";
             logger.Setup();
 
             if (!Platform.IsUnixLike())
@@ -112,6 +114,7 @@ namespace CyLRTests
             var userProfile = Environment.ExpandEnvironmentVariables("%HOME%");
             var logger = new CyLR.Logger();
             logger.LoggingOptions["output_file_path"] = "3.log";
+            logger.LoggingOptions["output_console_min_level"] = "error";
             logger.Setup();
 
             if (!Platform.IsUnixLike())
@@ -141,6 +144,7 @@ namespace CyLRTests
             var userProfile = Environment.ExpandEnvironmentVariables("%HOME%");
             var logger = new CyLR.Logger();
             logger.LoggingOptions["output_file_path"] = "4.log";
+            logger.LoggingOptions["output_console_min_level"] = "error";
             logger.Setup();
 
             if (!Platform.IsUnixLike())

--- a/CyLRTests/TestLogger.cs
+++ b/CyLRTests/TestLogger.cs
@@ -74,10 +74,10 @@ namespace CyLRTests
             logger.Setup();
 
             logger.logger(CyLR.Logger.Level.warn, "This is a warning!");
-            var now = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss");
-            var expected = $"{now} [warn] This is a warning!\n";
+            var expected = "[warn] This is a warning!\n";
+            var actual = logger.logMessages.Split(" ", 2)[1];
 
-            Assert.Equal(expected, logger.logMessages);
+            Assert.Equal(expected, actual);
             
             logger.TearDown();
         }
@@ -85,51 +85,51 @@ namespace CyLRTests
         [Fact]
         public void TestLoggerLevelMessages(){
             var logger = new CyLR.Logger();
-            var now = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss");
             string expected;
+            string actual;
 
             logger.Setup();
 
             logger.trace("This is a trace!");
-            now = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss");
-            expected = $"{now} [trace] This is a trace!\n";
-            Assert.Equal(expected, logger.logMessages);
+            expected = "[trace] This is a trace!\n";
+            actual = logger.logMessages.Split(" ", 2)[1];
+            Assert.Equal(expected, actual);
             logger.logMessages = "";
 
             logger.debug("This is a debug!");
-            now = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss");
-            expected = $"{now} [debug] This is a debug!\n";
-            Assert.Equal(expected, logger.logMessages);
+            expected = "[debug] This is a debug!\n";
+            actual = logger.logMessages.Split(" ", 2)[1];
+            Assert.Equal(expected, actual);
             logger.logMessages = "";
 
             logger.info("This is a info!");
-            now = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss");
-            expected = $"{now} [info] This is a info!\n";
-            Assert.Equal(expected, logger.logMessages);
+            expected = "[info] This is a info!\n";
+            actual = logger.logMessages.Split(" ", 2)[1];
+            Assert.Equal(expected, actual);
             logger.logMessages = "";
 
             logger.warn("This is a warning!");
-            now = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss");
-            expected = $"{now} [warn] This is a warning!\n";
-            Assert.Equal(expected, logger.logMessages);
+            expected = "[warn] This is a warning!\n";
+            actual = logger.logMessages.Split(" ", 2)[1];
+            Assert.Equal(expected, actual);
             logger.logMessages = "";
 
             logger.error("This is a error!");
-            now = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss");
-            expected = $"{now} [error] This is a error!\n";
-            Assert.Equal(expected, logger.logMessages);
+            expected = "[error] This is a error!\n";
+            actual = logger.logMessages.Split(" ", 2)[1];
+            Assert.Equal(expected, actual);
             logger.logMessages = "";
 
             logger.critical("This is a critical!");
-            now = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss");
-            expected = $"{now} [critical] This is a critical!\n";
-            Assert.Equal(expected, logger.logMessages);
+            expected = "[critical] This is a critical!\n";
+            actual = logger.logMessages.Split(" ", 2)[1];
+            Assert.Equal(expected, actual);
             logger.logMessages = "";
 
             logger.none("This is a none!");
-            now = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss");
-            expected = $"{now} [none] This is a none!\n";
-            Assert.Equal(expected, logger.logMessages);
+            expected = "[none] This is a none!\n";
+            actual = logger.logMessages.Split(" ", 2)[1];
+            Assert.Equal(expected, actual);
 
             logger.TearDown();
         }

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -1,5 +1,7 @@
 BUILD_DIR="." && [[ "$TRAVIS_BUILD_DIR" != "" ]] && BUILD_DIR=$TRAVIS_BUILD_DIR
 
+$ZIP_COMMAND="zip"
+
 unameOut="$(uname -s)"
 
 case "${unameOut}" in
@@ -15,12 +17,6 @@ esac
 
 if [ ! -d $BUILD_DIR/deployments/CyLR/$BUILD_ARCH ]; then
 	mkdir -p $BUILD_DIR/deployments/CyLR/$BUILD_ARCH
-fi
-
-if [ ! -f "./warp-packer" ] ; then
-
-	curl -Lo warp-packer "https://github.com/dgiagio/warp/releases/download/v0.3.0/$PACKER_ARCH.warp-packer"
-	chmod +x warp-packer
 fi
 
 cp -r $BUILD_DIR/CyLR/bin/Release/netcoreapp3.1/$BUILD_ARCH/publish/ $BUILD_DIR/deployments/CyLR


### PR DESCRIPTION
Closes #102 

Removes the timestamp comparison from unit tests since the test is to confirm log levels and handlers, not necessarily the timestamp. 

This should improve the reliability of the unit tests. 