### PR TITLE
Added UAL and RDP cache to CollectionPaths

### DIFF
--- a/CyLR/src/CollectionPaths.cs
+++ b/CyLR/src/CollectionPaths.cs
@@ -165,6 +165,7 @@ namespace CyLR
                     globPaths.Add(Glob.Parse(programData + @"\Microsoft\Windows\Start Menu\Programs\Startup\**"));
                     globPaths.Add(Glob.Parse(systemDrive + @"\$Recycle.Bin\**\$I*"));
                     globPaths.Add(Glob.Parse(systemDrive + @"\$Recycle.Bin\$I*"));
+                    globPaths.Add(Glob.Parse(systemRoot + @"\System32\Logfiles\SUM**"));
                     
                     staticPaths.Add(@"%SYSTEMROOT%\SchedLgU.Txt");
                     staticPaths.Add(@"%SYSTEMROOT%\inf\setupapi.dev.log");
@@ -206,6 +207,7 @@ namespace CyLR
                         globPaths.Add(Glob.Parse($@"{user.ProfilePath}\AppData\Roaming\Mozilla\Firefox\Profiles\**"));
                         globPaths.Add(Glob.Parse($@"{user.ProfilePath}\AppData\Local\ConnectedDevicesPlatform\**"));
                         globPaths.Add(Glob.Parse($@"{user.ProfilePath}\AppData\Local\Microsoft\Windows\Explorer\**"));
+                        globPaths.Add(Glob.Parse($@"{user.ProfilePath}\AppData\Local\Microsoft\Terminal Server Client\Cache\**"));
 
                         staticPaths.Add($@"{user.ProfilePath}\NTUSER.DAT");
                         staticPaths.Add($@"{user.ProfilePath}\NTUSER.DAT.LOG1");


### PR DESCRIPTION
Added the following to Collection Paths
-MS User Access Logs
https://advisory.kpmg.us/blog/2021/digital-forensics-incident-response.html
-RDP cache