### PR TITLE
Updated dotnet-core with the legacy URL

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -3,7 +3,7 @@
  <packageSources>
     <!--To inherit the global NuGet package sources remove the <clear/> line below -->
     <clear />
-    <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
+    <add key="dotnet-core" value="https://dotnetmygetlegacy.blob.core.windows.net/dotnet-core/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
  </packageSources>
 </configuration>


### PR DESCRIPTION
Previous url for dotnet-core didn't work as its no longer available. 
Added https://dotnetmygetlegacy.blob.core.windows.net/dotnet-core/index.json