### PR TITLE
Added RDP cache folder

### DIFF
--- a/CyLR/src/CollectionPaths.cs
+++ b/CyLR/src/CollectionPaths.cs
@@ -215,7 +215,8 @@ namespace CyLR
                         staticPaths.Add($@"{user.ProfilePath}\AppData\Local\Microsoft\Windows\UsrClass.dat.LOG2");
                         staticPaths.Add($@"{user.ProfilePath}\AppData\Local\Google\Chrome\User Data\Default\History");
                         staticPaths.Add($@"{user.ProfilePath}\AppData\Local\Microsoft\Edge\User Data\Default\History");
-                        staticPaths.Add($@"{user.ProfilePath}\AppData\Roaming\Microsoft\Windows\PowerShell\PSReadline\ConsoleHost_history.txt");
+                        staticPaths.Add($@"{user.ProfilePath}\AppData\Local\Microsoft\Terminal Server Client\Cache");
+                        staticPaths.Add($@"{user.ProfilePath}\AppData\Roaming\Microsoft\Windows\PowerShell\PSReadline\ConsoleHost_history.txt")
                     }
                 }
                 // Handle macOS platforms


### PR DESCRIPTION
RDP cache folder added to allow a detailed analysis of remote desktop sessions with tools like bmc-tools (https://github.com/ANSSI-FR/bmc-tools)